### PR TITLE
feat: Integrate terminal into the right pane

### DIFF
--- a/crates/corvus-core/src/app_state.rs
+++ b/crates/corvus-core/src/app_state.rs
@@ -90,6 +90,12 @@ pub enum PreviewContent {
     Binary,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RightPaneView {
+    Preview,
+    Terminal,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TabState {
     pub id: usize,
@@ -100,6 +106,7 @@ pub struct TabState {
     pub preview_content: Option<PreviewContent>,
     pub preview_scroll: (u16, u16),
     pub selected_entries: HashSet<PathBuf>,
+    pub right_pane_view: RightPaneView,
 }
 
 impl TabState {
@@ -113,6 +120,7 @@ impl TabState {
             preview_content: None,
             preview_scroll: (0, 0),
             selected_entries: HashSet::new(),
+            right_pane_view: RightPaneView::Preview,
         }
     }
 
@@ -287,7 +295,6 @@ pub struct AppState {
     #[serde(skip)]
     pub task_manager: TaskManager,
     pub clipboard: Clipboard,
-    pub show_terminal: bool,
     pub show_hidden_files: bool, // Re-add this
     #[serde(skip)]
     pub focus: FocusBlock,
@@ -378,7 +385,6 @@ impl AppState {
             show_tabs: false, // Hidden by default with one tab
             task_manager: TaskManager::new(),
             clipboard: Clipboard::new(),
-            show_terminal: false,
             show_hidden_files: false,
             focus: FocusBlock::Middle,
             xdg_dirs,
@@ -694,10 +700,6 @@ impl AppState {
                 self.show_tabs = false; // Hide tabs when only one is left
             }
         }
-    }
-
-    pub fn toggle_terminal(&mut self) {
-        self.show_terminal = !self.show_terminal;
     }
 
     pub fn add_bookmark(&mut self) {

--- a/crates/ui/src/layout.rs
+++ b/crates/ui/src/layout.rs
@@ -3,7 +3,6 @@ use ratatui::{
     prelude::{Constraint, Direction, Layout, Rect, Style},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
     Frame,
-    text::{Line},
 };
 use corvus_core::app_state::{AppState, CreateFileType, InputMode};
 use corvus_core::clipboard::ClipboardMode;
@@ -106,7 +105,7 @@ fn render_normal_layout(frame: &mut Frame, app_state: &AppState, color_scheme: &
     middle_pane::render_middle_pane(frame, middle_pane_inner_area, active_tab, color_scheme);
 
     // Right Pane
-    right_pane::render_right_pane(frame, right_pane_area, active_tab, color_scheme);
+    right_pane::render_right_pane(frame, right_pane_area, app_state, color_scheme);
 
     // --- Footer (Tasks, Info) ---
     let footer_chunks = Layout::default()
@@ -117,11 +116,7 @@ fn render_normal_layout(frame: &mut Frame, app_state: &AppState, color_scheme: &
         ])
         .split(footer_area);
 
-    if app_state.show_terminal {
-        render_terminal(frame, footer_chunks[0], app_state, color_scheme);
-    } else {
-        render_tasks_footer(frame, footer_chunks[0], app_state, color_scheme);
-    }
+    render_tasks_footer(frame, footer_chunks[0], app_state, color_scheme);
     render_info_panel(frame, footer_chunks[1], app_state, color_scheme);
 
     if app_state.show_confirmation {
@@ -250,23 +245,6 @@ fn render_tasks_footer(frame: &mut Frame, area: Rect, app_state: &AppState, colo
     let task_list = List::new(task_items);
 
     frame.render_widget(task_list, inner_area);
-}
-
-fn render_terminal(frame: &mut Frame, area: Rect, app_state: &AppState, color_scheme: &ColorScheme) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title("Terminal")
-        .style(Style::default()
-            .fg(color_scheme.text_color())
-            .bg(color_scheme.background()));
-    let inner_area = block.inner(area);
-    frame.render_widget(block.clone(), area);
-
-    if let Some(terminal_state) = &app_state.terminal {
-        let lines: Vec<Line> = terminal_state.lines.iter().map(|s| Line::from(s.as_str())).collect();
-        let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, inner_area);
-    }
 }
 
 fn render_info_panel(frame: &mut Frame, area: Rect, app_state: &AppState, color_scheme: &ColorScheme) {

--- a/crates/ui/src/right_pane.rs
+++ b/crates/ui/src/right_pane.rs
@@ -4,7 +4,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame,
 };
-use corvus_core::app_state::{PreviewContent, TabState};
+use corvus_core::app_state::{AppState, PreviewContent, RightPaneView};
 use corvus_core::settings::ColorScheme;
 use utils::icons::{get_color_for_file, get_icon_for_file, IconColor};
 
@@ -21,7 +21,37 @@ fn to_ratatui_color(icon_color: IconColor) -> ratatui::prelude::Color {
     }
 }
 
-pub fn render_right_pane(frame: &mut Frame, area: Rect, tab_state: &TabState, color_scheme: &ColorScheme) {
+pub fn render_right_pane(frame: &mut Frame, area: Rect, app_state: &AppState, color_scheme: &ColorScheme) {
+    let active_tab = app_state.get_active_tab();
+
+    match active_tab.right_pane_view {
+        RightPaneView::Preview => {
+            render_preview_pane(frame, area, active_tab, color_scheme);
+        }
+        RightPaneView::Terminal => {
+            render_terminal_pane(frame, area, app_state, color_scheme);
+        }
+    }
+}
+
+fn render_terminal_pane(frame: &mut Frame, area: Rect, app_state: &AppState, color_scheme: &ColorScheme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title("Terminal")
+        .style(Style::default()
+            .fg(color_scheme.text_color())
+            .bg(color_scheme.background()));
+    let inner_area = block.inner(area);
+    frame.render_widget(block.clone(), area);
+
+    if let Some(terminal_state) = &app_state.terminal {
+        let lines: Vec<Line> = terminal_state.lines.iter().map(|s| Line::from(s.as_str())).collect();
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, inner_area);
+    }
+}
+
+fn render_preview_pane(frame: &mut Frame, area: Rect, tab_state: &corvus_core::app_state::TabState, color_scheme: &ColorScheme) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title("Preview")

--- a/crates/ui/src/tui.rs
+++ b/crates/ui/src/tui.rs
@@ -5,7 +5,7 @@ use crossterm::{
 };
 use ratatui::prelude::{CrosstermBackend, Terminal};
 use std::io::{self, stdout, Stdout};
-use corvus_core::app_state::{AppState, InputMode, CreateFileType};
+use corvus_core::app_state::{AppState, InputMode, CreateFileType, RightPaneView};
 
 pub struct Tui {
     pub terminal: Terminal<CrosstermBackend<Stdout>>,
@@ -32,10 +32,11 @@ impl Tui {
 
 /// Handles key presses and returns `false` if the app should quit.
 pub fn handle_key_press(key: KeyEvent, app_state: &mut AppState) -> bool {
-    // The terminal is activated by pressing Ctrl+`. This is handled in the global keybindings.
-    if app_state.show_terminal {
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('`') {
-            app_state.toggle_terminal();
+    let active_tab_view = app_state.get_active_tab().right_pane_view.clone();
+
+    if active_tab_view == RightPaneView::Terminal {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('t') {
+            app_state.get_active_tab_mut().right_pane_view = RightPaneView::Preview;
             return true;
         }
 
@@ -96,8 +97,13 @@ pub fn handle_key_press(key: KeyEvent, app_state: &mut AppState) -> bool {
                 app_state.next_tab();
                 return true;
             }
-            KeyCode::Char('`') => {
-                app_state.toggle_terminal();
+            KeyCode::Char('t') => {
+                let active_tab = app_state.get_active_tab_mut();
+                if active_tab.right_pane_view == RightPaneView::Preview {
+                    active_tab.right_pane_view = RightPaneView::Terminal;
+                } else {
+                    active_tab.right_pane_view = RightPaneView::Preview;
+                }
                 return true;
             }
             KeyCode::Char('j') => {


### PR DESCRIPTION
This commit refactors the terminal functionality to be displayed in the right-hand pane, replacing the file preview when activated.

The key changes are:
- A new `RightPaneView` enum (`Preview`, `Terminal`) is added to the `TabState` to manage the content of the right pane on a per-tab basis.
- The previous global `show_terminal` state has been removed.
- The keybinding `Ctrl+t` is introduced to toggle between the file preview and the terminal view in the right pane.
- The old `Ctrl+\`` keybinding and the footer terminal have been removed.
- The UI rendering logic in `right_pane.rs` has been updated to conditionally render either the preview or the terminal.
- Keyboard input is now correctly forwarded to the terminal when it is active in the right pane.

This provides a more intuitive and powerful user experience by making the terminal a more central part of the application, directly addressing the user's request for a more prominent terminal interface.