### PR TITLE
Fix: Focus terminal on open

### DIFF
--- a/crates/corvus-core/src/app_state.rs
+++ b/crates/corvus-core/src/app_state.rs
@@ -35,6 +35,7 @@ pub enum FocusBlock {
     Xdg,
     Bookmarks,
     Disks,
+    Terminal,
 }
 
 use std::time::SystemTime;
@@ -502,6 +503,7 @@ impl AppState {
             FocusBlock::Bookmarks => FocusBlock::Disks,
             FocusBlock::Disks => FocusBlock::Middle,
             FocusBlock::Middle => FocusBlock::Xdg,
+            FocusBlock::Terminal => FocusBlock::Middle,
         };
     }
 
@@ -523,6 +525,7 @@ impl AppState {
                 }
             },
             FocusBlock::Middle => {}, // Should not happen
+            FocusBlock::Terminal => {}, // Should not happen
         }
         self.update_middle_pane_from_left_pane_selection();
     }
@@ -542,6 +545,7 @@ impl AppState {
                 }
             },
             FocusBlock::Middle => {}, // Should not happen
+            FocusBlock::Terminal => {}, // Should not happen
         }
         self.update_middle_pane_from_left_pane_selection();
     }
@@ -561,6 +565,7 @@ impl AppState {
                 }
             },
             FocusBlock::Middle => None, // No-op
+            FocusBlock::Terminal => None, // No-op
         };
 
         if let Some(path) = path {

--- a/crates/ui/src/tui.rs
+++ b/crates/ui/src/tui.rs
@@ -37,6 +37,7 @@ pub fn handle_key_press(key: KeyEvent, app_state: &mut AppState) -> bool {
     if active_tab_view == RightPaneView::Terminal {
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('t') {
             app_state.get_active_tab_mut().right_pane_view = RightPaneView::Preview;
+            app_state.focus = FocusBlock::Middle;
             return true;
         }
 
@@ -101,8 +102,10 @@ pub fn handle_key_press(key: KeyEvent, app_state: &mut AppState) -> bool {
                 let active_tab = app_state.get_active_tab_mut();
                 if active_tab.right_pane_view == RightPaneView::Preview {
                     active_tab.right_pane_view = RightPaneView::Terminal;
+                    app_state.focus = FocusBlock::Terminal;
                 } else {
                     active_tab.right_pane_view = RightPaneView::Preview;
+                    app_state.focus = FocusBlock::Middle;
                 }
                 return true;
             }

--- a/rtfm.log
+++ b/rtfm.log
@@ -129,3 +129,5 @@
 [2025-09-16][16:38:22][rtfm_core::app_state][INFO] Загружена сохраненная сессия
 [2025-09-16][16:39:36][app][INFO] Session saved successfully
 [2025-09-16][16:39:36][app][INFO] Application shutting down
+[2025-09-17][15:51:55][corvus][INFO] Application starting up
+[2025-09-17][15:51:55][corvus_core::app_state][INFO] Нет сохраненной сессии, создается новая


### PR DESCRIPTION
When opening the terminal with Ctrl+t, the focus was not being set to the terminal, preventing the user from typing immediately.

This change introduces a new focus state for the terminal and updates the key handling logic to set the focus to the terminal when it's opened and restore it when it's closed.